### PR TITLE
Fix 'overlapping loop device exists' error

### DIFF
--- a/box/box-mount
+++ b/box/box-mount
@@ -2,18 +2,20 @@ cd `dirname $0`
 
 # Get the starting offset of the root partition (not sure about trailing s)
 PART_BOOT_START=$(parted monster-mesh.img -ms unit s print | grep "^1" | cut -f 2 -d: | cut -f 1 -ds)
+PART_BOOT_SIZE=$(parted monster-mesh.img -ms unit s print | grep "^1" | cut -f 4 -d: | cut -f 1 -ds)
 PART_ROOT_START=$(parted monster-mesh.img -ms unit s print | grep "^2" | cut -f 2 -d: | cut -f 1 -ds)
-echo $PART_BOOT_START $PART_ROOT_START
+PART_ROOT_SIZE=$(parted monster-mesh.img -ms unit s print | grep "^2" | cut -f 4 -d: | cut -f 1 -ds)
+echo $PART_BOOT_START $PART_BOOT_SIZE $PART_ROOT_START $PART_ROOT_SIZE
 
 
 echo " mounting boot so we can fiddle with the config "
 mkdir boot
-sudo mount -o umask=0000,rw,loop,offset=$(($PART_BOOT_START * 512)) monster-mesh.img ./boot
+sudo mount -o umask=0000,rw,loop,offset=$(($PART_BOOT_START * 512)),sizelimit=$(($PART_BOOT_SIZE * 512)) monster-mesh.img ./boot
 #ls ./boot
 
 echo " mounting root so we can fiddle with the config "
 mkdir root
-sudo mount -o rw,loop,offset=$(($PART_ROOT_START * 512)) monster-mesh.img ./root
+sudo mount -o rw,loop,offset=$(($PART_ROOT_START * 512)),sizelimit=$(($PART_ROOT_SIZE * 512)) monster-mesh.img ./root
 #ls ./root
 
 echo " remember to umount before using the box "


### PR DESCRIPTION
Not specifying the sizelimit for mount causes an error in newer versions of mount.
Details: https://www.raspberrypi.org/forums/viewtopic.php?t=190154